### PR TITLE
Issue #2870868: Autoload fails if a module implements hook_boot and relies on a class autoloaded by registry_autoload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
+    - php: 5.3
 
 env:
   global:

--- a/registry_autoload.module
+++ b/registry_autoload.module
@@ -19,11 +19,11 @@ function registry_autoload_boot() {
  * Implements hook_module_implements_alter().
  */
 function registry_autoload_module_implements_alter(&$implementations, $hook) {
-  // Move our hook implementation to the bottom, so we are called last.
+  // Move our hook implementation to the top, so we are called first.
   if ($hook == 'registry_files_alter') {
     $group = $implementations['registry_autoload'];
     unset($implementations['registry_autoload']);
-    $implementations['registry_autoload'] = $group;
+    $implementations = array('registry_autoload' => $group) + $implementations;
   }
 }
 


### PR DESCRIPTION
Ref. https://www.drupal.org/node/2870868